### PR TITLE
fixed browser errors on page load

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -17,7 +17,9 @@ const config = {
 				'default-src': ['none'],
 				'img-src': ['self' ],
 				'script-src': ['self' ],
-				'style-src': ['self' ]
+				// i can't work out how to get inline styles working properly
+				// i'd rather avoid all unsafe things in here
+				'style-src': ['self', 'unsafe-inline' ] 
 			}
 		}
 	},

--- a/tests/observatory_test.ts
+++ b/tests/observatory_test.ts
@@ -11,4 +11,14 @@ test("has security policy header", async ({ page }) => {
     const headers = response!.headers()!;
     expect(headers["content-security-policy"]).toContain("default-src 'none'");
 })
-    
+
+test("no console errors", async ({ page }) => {
+    let errors: string[] = [];
+    page.on("console", (msg) => {
+        if (msg.type() === "error") {
+            errors.push(msg.text());
+        }
+    });
+    await page.goto("/");
+    expect(errors).toEqual([]);
+})


### PR DESCRIPTION
allowing unsafe inline css is not ideal, but i can't work out how to get it to hash/nonce them properly. this should be fixed later.